### PR TITLE
Move *.ts to safe category

### DIFF
--- a/patterns.json
+++ b/patterns.json
@@ -1,6 +1,6 @@
 {
     "$default": "safe",
-    
+
     "safe": {
         "patterns": [
             "readme*",
@@ -92,15 +92,16 @@
             "desktop.ini",
             "npm-debug.log",
             "wercker.yml",
-            ".flowconfig"
+            ".flowconfig",
+            "*.ts"
         ],
-        
+
         "ignore": [
             "validate-npm-package-license",
             "spdx-license-ids"
         ]
     },
-    
+
     "caution": {
         "patterns": [
             "*.png",
@@ -126,14 +127,13 @@
             "*.cc",
             "*.cpp"
         ],
-        
+
         "ignore": []
     },
-    
+
     "danger": {
         "patterns": [
             "*.coffee",
-            "*.ts",
             ".bin",
             "*.min.js",
             "test.js",
@@ -152,7 +152,7 @@
             "uglifyjs",
             "yarn.lock"
         ],
-        
+
         "ignore": []
     }
 }


### PR DESCRIPTION
Typescript files are always safe to delete because they will never work in Node.js. This will result in significant size reductions.

Also cleaned up some superfluous whitespace my editor automatically picked up.

Fixes https://github.com/ModClean/modclean-patterns-default/issues/5